### PR TITLE
put-resources-pipeline - resource_type/source/tags -> tag

### DIFF
--- a/docs/examples/pipeline/put-resources-pipeline.yml
+++ b/docs/examples/pipeline/put-resources-pipeline.yml
@@ -5,7 +5,7 @@ resource_types:
   type: docker-image
   source:
     repository: pivotalcf/pivnet-resource
-    tags: latest-final
+    tag: latest-final
 
 resources:
 - name: daily


### PR DESCRIPTION
According to `https://concourse-ci.org/resource-types.html` `tags` is a type [string] .

This also generates error in VS Code Concourse plugin linter with; "Unknown property 'tags' for type 'DockerImageSource'"

I believe `tags` should be replaced with `tag`.