### PR TITLE
fix camelcase for vSphere

### DIFF
--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -188,7 +188,7 @@ The task does specific CLI commands for the deletion of the Ops Manager VM and r
 1. Deletes the VM
 1. Attempts to delete the associated image
 
-**Vsphere**
+**vSphere**
 
 1. Deletes the VM
 


### PR DESCRIPTION
Small change, but using the correct case for vSphere will build credibility in our customer base that Pivotal knows VMware products, including vSphere.