### PR TITLE
proper lookup for RSA private key

### DIFF
--- a/docs/how-to-guides/install-opsman.md
+++ b/docs/how-to-guides/install-opsman.md
@@ -175,7 +175,7 @@ Then, add this to the resources section of your pipeline file:
   type: git
   source:
     uri: ((pipeline-repo))
-    private_key: ((plat-auto-pipes-deploy-key))
+    private_key: ((plat-auto-pipes-deploy-key.private_key))
     branch: master
 ```
 


### PR DESCRIPTION
interpolation for git ssh key is 
`private_key: ((plat-auto-pipes-deploy-key.private_key))`
 and not
` private_key: ((plat-auto-pipes-deploy-key))`