### PR TITLE
Update link for external dependencies

### DIFF
--- a/docs/compatibility-and-versioning.md
+++ b/docs/compatibility-and-versioning.md
@@ -58,7 +58,7 @@ These are all documented for each task within the task files themselves.
 Additionally, the minimum compatible version
 of Concourse and Ops Manager
 are part of the API,
-and are specified [below][external-deps].
+and are specified [here][external-deps].
 
 The following are NOT covered:
 


### PR DESCRIPTION
It is no longer "below" -- it's now "above". Change the link text to "here" so that if it moves again, this continues to make sense.