### PR TITLE
Prepare the docs-platform-automation for paving v3.0.0

### DIFF
--- a/ci/dockerfiles/Dockerfile.ci
+++ b/ci/dockerfiles/Dockerfile.ci
@@ -15,8 +15,8 @@ RUN wget "https://dl.minio.io/client/mc/release/linux-amd64/mc" && \
     chmod +x mc && \
     mv mc /usr/bin/mc
 
-RUN wget https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip && \
-    unzip terraform_0.13.5_linux_amd64.zip -d /usr/bin
+RUN wget https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_amd64.zip && \
+    unzip terraform_1.0.11_linux_amd64.zip -d /usr/bin
 
 # install BOSH
 RUN wget "https://github.com/cloudfoundry/bosh-cli/releases/download/v6.2.1/bosh-cli-6.2.1-linux-amd64" -O bosh

--- a/ci/tasks/create-infrastructure/task.sh
+++ b/ci/tasks/create-infrastructure/task.sh
@@ -38,6 +38,8 @@ cp "$deployment_path"/terraform.tfvars "$terraform_path"
 
 cd "$terraform_path"
 
+terraform version
+
 terraform init
 
 terraform refresh \
@@ -54,4 +56,13 @@ terraform apply \
   -parallelism=5 \
   terraform.tfplan
 
-terraform output stable_config_opsmanager > terraform-vars.yml
+terraform_major_version=$(terraform version | head -n1 | cut -d " " -f2 | cut -d "." -f1)
+terraform_minor_version=$(terraform version | head -n1 | cut -d " " -f2 | cut -d "." -f2)
+
+# If terraform version is 13 or below use terraform output without format option
+if [[ $terraform_major_version == "v0" && $terraform_minor_version -le 13 ]]
+then
+  terraform output stable_config_opsmanager > terraform-vars.yml
+else
+  terraform output -raw stable_config_opsmanager > terraform-vars.yml
+fi


### PR DESCRIPTION
- Upgraded `Terraform CLI` to `v1.0.11`
- Added a `Terraform` version check to the `create-infrastructure` task to make it backward compatible with `Terraform v0.13`