### PR TITLE
Fixing the the docker registry url to go through jfrog proxy

### DIFF
--- a/ci/tasks/leftovers.yml
+++ b/ci/tasks/leftovers.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
     tag: testing
 params:
   # A list of IAAS specific authentication and targeting params.


### PR DESCRIPTION
Fixing the the docker registry url to go through jfrog proxy