### PR TITLE
Update CI tasks to use internal image registry

### DIFF
--- a/ci/ci/pipeline.yml
+++ b/ci/ci/pipeline.yml
@@ -44,10 +44,10 @@ resources:
 - name: ci-image
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: ((platform-automation/main/docker.ci-repository))
+    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
 - name: docs-platform-automation
   type: git
   source:
@@ -92,31 +92,31 @@ resources:
 - name: packages-image
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: internalpcfplatformautomation/platform-automation
+    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/platform-automation
     tag: packages
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
 - name: packages-image-oci
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: internalpcfplatformautomation/platform-automation
+    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/platform-automation
     tag: packages
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
 - name: binaries-image
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: internalpcfplatformautomation/platform-automation
+    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/platform-automation
     tag: testing
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
 - name: vsphere-only-image
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: internalpcfplatformautomation/platform-automation
+    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/platform-automation
     tag: vsphere-only
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
 - name: osl
   type: s3-with-arn
   source:
@@ -424,7 +424,7 @@ resource_types:
 - name: buildinfo
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: buildinfo
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
@@ -698,7 +698,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+          repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
           tag: testing
           username: ((concourse-team/dev_image_registry.username))
           password: ((concourse-team/dev_image_registry.password))
@@ -1648,7 +1648,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+          repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
           tag: testing
           username: ((concourse-team/dev_image_registry.username))
           password: ((concourse-team/dev_image_registry.password))

--- a/ci/tasks/check-osl-reuse-validity.yml
+++ b/ci/tasks/check-osl-reuse-validity.yml
@@ -3,8 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 
 inputs:
 - name: rc-image-receipt-s3

--- a/ci/tasks/create-infrastructure/task.yml
+++ b/ci/tasks/create-infrastructure/task.yml
@@ -9,7 +9,7 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
     tag: testing

--- a/ci/tasks/create-pks-cluster/task.yml
+++ b/ci/tasks/create-pks-cluster/task.yml
@@ -2,8 +2,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 inputs:
   - name: pks-cli
   - name: docs-platform-automation

--- a/ci/tasks/delete-infrastructure/task.yml
+++ b/ci/tasks/delete-infrastructure/task.yml
@@ -9,10 +9,10 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
+    tag: testing
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
-    tag: testing
 params:
   IAAS:
 run:

--- a/ci/tasks/delete-state-file.yml
+++ b/ci/tasks/delete-state-file.yml
@@ -3,10 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
+    tag: testing
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
-    tag: testing
 
 inputs:
 - name: deployments

--- a/ci/tasks/docs-task-test.yml
+++ b/ci/tasks/docs-task-test.yml
@@ -2,8 +2,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 inputs:
 - name: docs-platform-automation
 caches:

--- a/ci/tasks/download-product.yml
+++ b/ci/tasks/download-product.yml
@@ -4,10 +4,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 params:
   OM_pivnet_token:
 run:

--- a/ci/tasks/generate-config/task.yml
+++ b/ci/tasks/generate-config/task.yml
@@ -11,8 +11,10 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 params:
   IAAS:
   BOSH_ENV_PREFIX:

--- a/ci/tasks/leftovers.yml
+++ b/ci/tasks/leftovers.yml
@@ -2,10 +2,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
+    tag: testing
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
-    tag: testing
 params:
   # A list of IAAS specific authentication and targeting params.
   BBL_IAAS:

--- a/ci/tasks/make-commit/task.yml
+++ b/ci/tasks/make-commit/task.yml
@@ -9,8 +9,10 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 params:
   IAAS:
 run:

--- a/ci/tasks/package-for-release/platform-automation.yml
+++ b/ci/tasks/package-for-release/platform-automation.yml
@@ -20,8 +20,10 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 run:
   path: bash
   args:

--- a/ci/tasks/pivnet-release/empty-cve-patch-notes.yml
+++ b/ci/tasks/pivnet-release/empty-cve-patch-notes.yml
@@ -3,8 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 
 inputs:
 - name: docs-platform-automation

--- a/ci/tasks/pivnet-release/generate-platform-automation-metadata-bump.yml
+++ b/ci/tasks/pivnet-release/generate-platform-automation-metadata-bump.yml
@@ -3,8 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 
 inputs:
 - name: version

--- a/ci/tasks/pivnet-release/generate-platform-automation-metadata-v5.1.yml
+++ b/ci/tasks/pivnet-release/generate-platform-automation-metadata-v5.1.yml
@@ -3,8 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 
 inputs:
 - name: version

--- a/ci/tasks/pivnet-release/generate-release-notes.yml
+++ b/ci/tasks/pivnet-release/generate-release-notes.yml
@@ -3,8 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 
 params:
   GITHUB_SSH_KEY:

--- a/ci/tasks/rename-om-binary.yml
+++ b/ci/tasks/rename-om-binary.yml
@@ -6,10 +6,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
-    username: ((concourse-team/dev_image_registry.username))                                           
-    password: ((concourse-team/dev_image_registry.password))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 run:
   path: bash
   args:

--- a/ci/tasks/rename-windows-stemcell/task.yml
+++ b/ci/tasks/rename-windows-stemcell/task.yml
@@ -8,7 +8,9 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 run:
   path: docs-platform-automation/ci/tasks/rename-windows-stemcell/task.rb

--- a/ci/tasks/scan-and-submit-sboms.yml
+++ b/ci/tasks/scan-and-submit-sboms.yml
@@ -3,10 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
+    tag: testing
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
-    tag: testing
 
 inputs:
   - name: version

--- a/ci/tasks/secrets-verifier/task.yml
+++ b/ci/tasks/secrets-verifier/task.yml
@@ -6,10 +6,10 @@ inputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((concourse-team/dev_image_registry.url))/((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
+    tag: testing
     username: ((concourse-team/dev_image_registry.username))
     password: ((concourse-team/dev_image_registry.password))
-    tag: testing
 run:
   path: bash
   args:

--- a/ci/tasks/show-director-config.yml
+++ b/ci/tasks/show-director-config.yml
@@ -2,8 +2,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 inputs:
   - name: generated-config
 run:

--- a/ci/tasks/test-and-build-om.yml
+++ b/ci/tasks/test-and-build-om.yml
@@ -2,10 +2,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    password: ((platform-automation/main/docker.password))
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
-    username: ((platform-automation/main/docker.username))
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))
 inputs:
 - name: om
 - name: docs-platform-automation

--- a/ci/tasks/update-docs-ref.yml
+++ b/ci/tasks/update-docs-ref.yml
@@ -26,5 +26,7 @@ outputs:
 image_resource:
   type: registry-image
   source:
-    repository: ((platform-automation/main/docker.ci-repository))
+    repository: ((concourse-team/dev_image_registry.dev_url))/internalpcfplatformautomation/ci
     tag: testing
+    username: ((concourse-team/dev_image_registry.username))
+    password: ((concourse-team/dev_image_registry.password))


### PR DESCRIPTION
Internal infrastructure constraints demanded that we move our image hosting from Docker Hub to an internal image repository