### PR TITLE
TNZ-32337 - Add expiring licenses check script and configuration

### DIFF
--- a/tasks/expiring-licenses.sh
+++ b/tasks/expiring-licenses.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# code_snippet expiring-licenses-script start bash
+
+cat /var/version && echo ""
+set -eux
+
+# Build the command with optional flags
+cmd="om --env env/"${ENV_FILE}" expiring-licenses --format json"
+
+if [ -n "${EXPIRES_WITHIN:-}" ]; then
+  cmd="${cmd} --expires-within ${EXPIRES_WITHIN}"
+fi
+
+if [ "${STAGED:-false}" = "true" ]; then
+  cmd="${cmd} --staged"
+fi
+
+if [ "${DEPLOYED:-false}" = "true" ]; then
+  cmd="${cmd} --deployed"
+fi
+
+# Run the command and capture the output
+output=$(${cmd})
+
+# Check if there are any expiring licenses (empty array means no licenses)
+if [ "$output" != "[]" ]; then
+  echo "Found expiring licenses:"
+  echo "$output"
+  exit 1
+fi
+
+echo "No expiring licenses found within ${EXPIRES_WITHIN:-3m}"
+# code_snippet expiring-licenses-script end

--- a/tasks/expiring-licenses.yml
+++ b/tasks/expiring-licenses.yml
@@ -1,0 +1,42 @@
+# The inputs, outputs, params, filename, and filepath
+# of this task file are part of its semantically versioned API.
+# See our documentation for a detailed discussion of our semver API.
+# See www.semver.org for an explanation of semantic versioning.
+
+# code_snippet expiring-licenses start yaml
+---
+platform: linux
+
+inputs:
+  - name: platform-automation-tasks
+  - name: env # contains the env file with target OpsMan Information
+
+params:
+  ENV_FILE: env.yml
+  # - Required
+  # - Filepath of the env config YAML
+  # - The path is relative to root of the `env` input
+
+  EXPIRES_WITHIN:
+  # - Optional
+  # - Example: "3m" is 3 months
+  # - Check for licenses expiring within the defined time period
+  # - Supports a time period defined with a suffix of:
+  #   days(d), weeks(w), months(m) and years(y)
+  # - Defaults to "3m" if not specified
+
+  STAGED:
+  # - Optional
+  # - Boolean flag
+  # - Include staged products in the check
+  # - Defaults to false if not specified
+
+  DEPLOYED:
+  # - Optional
+  # - Boolean flag
+  # - Include deployed products in the check
+  # - Defaults to false if not specified
+
+run:
+  path: platform-automation-tasks/tasks/expiring-licenses.sh
+# code_snippet expiring-licenses end


### PR DESCRIPTION
This pull request introduces a new script and accompanying configuration file for checking expiring licenses. The script is designed to be flexible, allowing for various optional parameters to tailor the behavior of the license check.

Key changes include:

### New Script for Expiring Licenses Check:
* Added a new Bash script `tasks/expiring-licenses.sh` to check for expiring licenses with configurable parameters such as `EXPIRES_WITHIN`, `STAGED`, and `DEPLOYED`.

### Configuration for the New Script:
* Created a new YAML configuration file `tasks/expiring-licenses.yml` to define the inputs, parameters, and execution path for the expiring licenses check task.
* This file includes detailed comments explaining the purpose and usage of each parameter.
* Introduce a new script to check for expiring licenses and a corresponding YAML configuration file.
* The script captures output based on specified parameters, reports any licenses that are expiring within a defined timeframe, and exits with exit 1.

### **DO NOT MERGE UNTIL**
- https://github.com/pivotal-cf/om/pull/687