### PR TITLE
update PA dependency table and add missing 5.2.0 and 5.2.1 release notes

### DIFF
--- a/docs/compatibility-and-versioning.html.md.erb
+++ b/docs/compatibility-and-versioning.html.md.erb
@@ -17,6 +17,12 @@ Platform Automation Toolkit is designed to work with these dependencies.
 </thead>
 <tbody>
     <tr>
+        <td>v5.3.0+</td>
+        <td><a href="https://concourse-ci.org"><code>v6.7.9+</code></a><sup>2</sup></td>
+        <td><a href="https://network.pivotal.io/products/ops-manager/">v3.1+</a></td>
+        <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
+    </tr>
+    <tr>
         <td>v5.1.2+</td>
         <td><a href="https://concourse-ci.org"><code>v6.7.9+</code></a><sup>2</sup></td>
         <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>

--- a/docs/release-notes.html.md.erb
+++ b/docs/release-notes.html.md.erb
@@ -84,6 +84,50 @@ The full Docker image-receipt: <a href="https://platform-automation-release-cand
 ## v5.2.1
 July 26, 2024
 
+**CLI Versions**
+
+| Name | version |
+|---|---|
+| aws-cli | [1.33.30](https://github.com/aws/aws-cli/releases/tag/1.33.30) |
+| azure-cli | [2.62.0](https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.62.0) |
+| bbr-cli | [1.9.66](https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/tag/v1.9.66) |
+| bosh-cli | [v7.6.2](https://github.com/cloudfoundry/bosh-cli/releases/tag/v7.6.2) |
+| credhub | [2.9.35](https://github.com/cloudfoundry-incubator/credhub-cli/releases/tag/2.9.35) |
+| gcloud-cli | 485.0.0 |
+| govc-cli | [0.39.0](https://github.com/vmware/govmomi/releases/tag/v0.39.0) |
+| om | [7.13.0](https://github.com/pivotal-cf/om/releases/tag/7.13.0) |
+| winfs-injector | [0.26.0](https://github.com/pivotal-cf/winfs-injector/releases/tag/0.26.0) |
+
+The full Docker image-receipt: <a href="https://platform-automation-release-candidate.s3-us-west-2.amazonaws.com/image-receipt-5.2.1" target="_blank">Download</a>
+
+### What's New
+
+* `om` has been updated to 7.13.0 for bug fixes and dependency updates.
+* Adds `FORCE_LATEST_VARIABLES` param to apply changes tasks by @selzoc in #52
+
+
+## v5.2.0
+June 28, 2024
+
+**CLI Versions**
+
+| Name | version |
+|---|---|
+| aws-cli | [1.33.13](https://github.com/aws/aws-cli/releases/tag/1.33.13) |
+| azure-cli | [2.61.0](https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.61.0) |
+| bbr-cli | [1.9.66](https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/tag/v1.9.66) |
+| bosh-cli | [v7.6.1](https://github.com/cloudfoundry/bosh-cli/releases/tag/v7.6.1) |
+| credhub | [2.9.33](https://github.com/cloudfoundry-incubator/credhub-cli/releases/tag/2.9.33) |
+| gcloud-cli | 481.0.0 |
+| govc-cli | [0.37.3](https://github.com/vmware/govmomi/releases/tag/v0.37.3) |
+| om | [7.12.0](https://github.com/pivotal-cf/om/releases/tag/7.12.0) |
+| winfs-injector | [0.25.0](https://github.com/pivotal-cf/winfs-injector/releases/tag/0.25.0) |
+
+The full Docker image-receipt: <a href="https://platform-automation-release-candidate.s3-us-west-2.amazonaws.com/image-receipt-5.1.2" target="_blank">Download</a>
+
+### What's New
+* `om` has been updated to 7.12.0 in order to have the Auto-Accept EULA functionality for TanzuNet depreciation.
+
 
 ## v5.1.2
 


### PR DESCRIPTION
This PR updates the PA dependency table and also updates the missing release notes for version 5.2.0 and 5.2.1(not sure why they are missing)