### PR TITLE
remove unsupported versions and add a note for PA 5.3.0 release

### DIFF
--- a/docs/compatibility-and-versioning.html.md.erb
+++ b/docs/compatibility-and-versioning.html.md.erb
@@ -17,9 +17,9 @@ Platform Automation Toolkit is designed to work with these dependencies.
 </thead>
 <tbody>
     <tr>
-        <td>v5.3.0+</td>
+        <td>v5.3.0+</a><sup>3</sup></td>
         <td><a href="https://concourse-ci.org"><code>v6.7.9+</code></a><sup>2</sup></td>
-        <td><a href="https://network.pivotal.io/products/ops-manager/">v3.1+</a></td>
+        <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</td>
         <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
     </tr>
     <tr>
@@ -30,30 +30,6 @@ Platform Automation Toolkit is designed to work with these dependencies.
     </tr>
     <tr>
         <td>v5.1.0</td>
-        <td><a href="https://concourse-ci.org"><code>v5.0.0+</code></a><sup>1</sup></td>
-        <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>
-        <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
-    </tr>
-    <tr>
-        <td>v5.0.25+</td>
-        <td><a href="https://concourse-ci.org"><code>v6.7.9+</code></a><sup>2</sup></td>
-        <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>
-        <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
-    </tr>
-    <tr>
-        <td>v5.0.0</td>
-        <td><a href="https://concourse-ci.org"><code>v5.0.0+</code></a><sup>1</sup></td>
-        <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>
-        <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
-    </tr>
-    <tr>
-        <td>v4.4.32+</td>
-        <td><a href="https://concourse-ci.org"><code>v6.7.9+</code></a><sup>2</sup></td>
-        <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>
-        <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
-    </tr>
-    <tr>
-        <td>v4.4.0</td>
         <td><a href="https://concourse-ci.org"><code>v5.0.0+</code></a><sup>1</sup></td>
         <td><a href="https://network.pivotal.io/products/ops-manager/">v2.3+</a></td>
         <td><a href="https://github.com/pivotal-cf/pivnet-resource">v0.31.15</a></td>
@@ -72,6 +48,8 @@ Platform Automation Toolkit is designed to work with these dependencies.
     Because of fundamental issues with the cgroup to cgroupv2 transition that happened between bionic and jammy, this requires changes to Concourse that are only available in Concourse v6.7.9+.
     If you are using a version of Concourse prior to v6.7.9, you must use the Ubuntu Bionic based image.
 
+<sup>3</sup>
+    If you are using `expiring-licenses` task from Platform Automation v5.3.0+, the Ops Manager version must be v3.1.0+
 
 ## Semantic Versioning
 This product uses [semantic versioning][semver] 2.0.0


### PR DESCRIPTION
This PR updates dependency table by removing the unsupported PA versions and adds a note about using `expiring-licenses` task from PA v5.3.0 release