### PR TITLE
fix(ci): update MinIO client command syntax for download-product task

### DIFF
--- a/ci/tasks/download-product.yml
+++ b/ci/tasks/download-product.yml
@@ -57,7 +57,7 @@ run:
 
     ls downloads-pivnet/
 
-    mc config host add local http://localhost:9000 minio password
+    mc alias set local http://localhost:9000 minio password
     mc mb local/bucket
     mc cp -q "$PWD"/downloads-pivnet/*.pivotal local/bucket/product-path/
     mc cp -q "$PWD"/downloads-pivnet/*.tgz local/bucket/stemcell-path/


### PR DESCRIPTION
- Replace deprecated 'mc config host add' with 'mc alias set'
- Fixes CI pipeline failure caused by upstream MinIO client breaking change

The 'mc config' command was removed in minio/mc#5201, requiring migration to 'mc alias set' syntax for newer MinIO client versions.

Resolves: CI pipeline failure in download-product task