### PR TITLE
fix release notes file extension

### DIFF
--- a/ci/scripts/generate-release-notes/generate-release-notes.go
+++ b/ci/scripts/generate-release-notes/generate-release-notes.go
@@ -228,7 +228,7 @@ func getReleaseNotes(docsRepoDir string) ([]byte, error) {
 		return []byte{}, fmt.Errorf("the provided '%s' is not a directory", docsRepoDir)
 	}
 
-	releaseNotes, err := ioutil.ReadFile(filepath.Join(docsRepoDir, "docs", "release-notes.md"))
+	releaseNotes, err := ioutil.ReadFile(filepath.Join(docsRepoDir, "docs", "release-notes.html.md.erb"))
 	if err != nil {
 		return []byte{}, err
 	}
@@ -269,7 +269,7 @@ func generateReleaseNotes(docsRepoDir, minorVersion string, header []byte, secti
 
 	// Get the appropriate file path based on version
 	// The 5.2 branch is using the html.md.erb file type, as requested by the Docs team
-	releaseNotesPath := filepath.Join(docsRepoDir, "docs", "release-notes.md")
+	releaseNotesPath := filepath.Join(docsRepoDir, "docs", "release-notes.html.md.erb")
 	if minorVersion == "5.2" {
 		releaseNotesPath = filepath.Join(docsRepoDir, "docs", "release-notes.html.md.erb")
 	}

--- a/ci/scripts/generate-release-notes/generate_release_notes_test.go
+++ b/ci/scripts/generate-release-notes/generate_release_notes_test.go
@@ -2,14 +2,15 @@ package main_test
 
 import (
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("GenerateReleaseNotes", func() {
@@ -33,7 +34,7 @@ var _ = Describe("GenerateReleaseNotes", func() {
 		err = repo.run("remote", "add", "origin", upstreamRepo.dir)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = repo.write("docs/release-notes.md", stableReleaseNotes)
+		err = repo.write("docs/release-notes.html.md.erb", stableReleaseNotes)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = repo.run("add", "-A")
@@ -56,7 +57,7 @@ var _ = Describe("GenerateReleaseNotes", func() {
 			Eventually(session).Should(gexec.Exit(0))
 
 			By("keeping all the release notes on develop")
-			notes, err := repo.readFileFrom("develop", "docs/release-notes.md")
+			notes, err := repo.readFileFrom("develop", "docs/release-notes.html.md.erb")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(notes).To(Equal(stableReleaseNotes))
 
@@ -83,7 +84,7 @@ var _ = Describe("GenerateReleaseNotes", func() {
 	When("automatically adding release notes", func() {
 		When("the release notes have been previously generated", func() {
 			It("errors with a helpful message", func() {
-				err := repo.write("docs/release-notes.md", stableReleaseNotes + "\n\n## v1.0.1")
+				err := repo.write("docs/release-notes.html.md.erb", stableReleaseNotes+"\n\n## v1.0.1")
 				Expect(err).NotTo(HaveOccurred())
 
 				err = repo.run("add", "-A")
@@ -133,7 +134,7 @@ var _ = Describe("GenerateReleaseNotes", func() {
 			Eventually(session).Should(gexec.Exit(0))
 
 			By("keeping all the release notes on develop")
-			notes, err := repo.readFileFrom("develop", "docs/release-notes.md")
+			notes, err := repo.readFileFrom("develop", "docs/release-notes.html.md.erb")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(notes).To(ContainSubstring(expectedReleaseNotesWithPatches))
 

--- a/ci/scripts/insert-cli-versions-into-release-notes/insert-cli-versions-into-release-notes_test.go
+++ b/ci/scripts/insert-cli-versions-into-release-notes/insert-cli-versions-into-release-notes_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Insert cli versions into release notes script", func() {
 
 	When("improper number of arguments are provided", func() {
 		It("gives an error saying a path to the release notes file, version table, and version number are required", func() {
-			command := exec.Command(compiledPath, "release-notes.md", "versionTable.md")
+			command := exec.Command(compiledPath, "release-notes.html.md.erb", "versionTable.md")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -170,7 +170,6 @@ etc
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
-
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))
 				Expect(session.Err).To(gbytes.Say(regexp.QuoteMeta("the requested version is not present in the release notes")))
@@ -183,7 +182,6 @@ etc
 				command := exec.Command(compiledPath, releaseNotesFile.Name(), versionTableFile.Name(), versionArg)
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-
 
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))


### PR DESCRIPTION
This PR fixes the release-notes.md file extension to release-notes.html.md.erb as that is the format recognized by docs generator 