### PR TITLE
Add SPNEGO proxy authentication support for download-product

### DIFF
--- a/ci/ci/pipeline.yml
+++ b/ci/ci/pipeline.yml
@@ -1735,6 +1735,76 @@ jobs:
           NAME: my-runtime-config
           BOSH_ENV_PREFIX: OPSMAN
           OPSMAN_SSH_PRIVATE_KEY: ((platform-automation/main/reference-pipeline.ops_manager_ssh_private_key))
+    #! Test SPNEGO proxy authentication using external proxy
+    - do:
+      - task: prepare-spnego-config
+        image: platform-automation-image
+        config:
+          platform: linux
+          outputs:
+            - name: spnego-config
+          params:
+            PIVNET_TOKEN: ((platform-automation/main.pivnet_token))
+            PROXY_URL: ((platform-automation/main.spnego_proxy_url))
+            PROXY_USERNAME: ((platform-automation/main.spnego_proxy_username))
+            PROXY_PASSWORD: ((platform-automation/main.spnego_proxy_password))
+            KDC_HOST: ((platform-automation/main.spnego_kdc_host))
+            KRB5_CONF_CONTENT: |
+              [libdefaults]
+                  default_realm = TEST.LOCAL
+                  dns_lookup_realm = false
+                  dns_lookup_kdc = false
+                  forwardable = true
+
+              [realms]
+                  TEST.LOCAL = {
+                      kdc = ((platform-automation/main.spnego_kdc_host))
+                      admin_server = ((platform-automation/main.spnego_kdc_host))
+                  }
+
+              [domain_realm]
+                  .test.local = TEST.LOCAL
+                  test.local = TEST.LOCAL
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux
+
+                echo "=== Verifying SPNEGO proxy connectivity ==="
+                if curl -s --proxy "${PROXY_URL}" --max-time 10 -I http://google.com 2>/dev/null | grep -q "HTTP/"; then
+                  echo "Proxy is reachable!"
+                else
+                  echo "WARNING: Cannot reach proxy at ${PROXY_URL}"
+                fi
+
+                echo "=== Creating SPNEGO config ==="
+                echo "${KRB5_CONF_CONTENT}" > spnego-config/krb5.conf
+
+                cat > spnego-config/download-config.yml << EOF
+                ---
+                pivnet-api-token: ${PIVNET_TOKEN}
+                pivnet-file-glob: "*vsphere*.tgz"
+                pivnet-product-slug: stemcells-ubuntu-jammy
+                product-version-regex: '^1\..*'
+                proxy-url: ${PROXY_URL}
+                proxy-username: ${PROXY_USERNAME}
+                proxy-password: ${PROXY_PASSWORD}
+                proxy-auth-type: spnego
+                proxy-krb5-config: config/krb5.conf
+                EOF
+
+                echo "Config created:"
+                cat spnego-config/download-config.yml
+      - task: test-spnego-download-product
+        image: platform-automation-image
+        file: platform-automation-tasks/tasks/download-product.yml
+        input_mapping:
+          config: spnego-config
+        params:
+          CONFIG_FILE: download-config.yml
+          SOURCE: pivnet
 
 #! bump jobs
 - name: bump-previous-versions-trigger

--- a/ci/spnego-infra/install.sh
+++ b/ci/spnego-infra/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Install SPNEGO Infrastructure as a systemd service
+#
+# Prerequisites:
+#   Create /opt/spnego-infra/env with:
+#     DOCKER_REGISTRY_PASSWORD=<your-jfrog-api-key>
+#
+# Run this on the jumpbox worker:
+#   sudo ./install.sh
+#
+# After installation:
+#   sudo systemctl status spnego-infra
+#   sudo systemctl restart spnego-infra
+
+set -eux
+
+INSTALL_DIR="/opt/spnego-infra"
+
+echo "=== Installing SPNEGO Infrastructure Service ==="
+
+# Create install directory
+mkdir -p ${INSTALL_DIR}
+
+# Copy setup script
+cp setup-spnego-infra.sh ${INSTALL_DIR}/
+chmod +x ${INSTALL_DIR}/setup-spnego-infra.sh
+
+# Install systemd service
+cp spnego-infra.service /etc/systemd/system/
+
+# Reload systemd
+systemctl daemon-reload
+
+# Enable and start service
+systemctl enable spnego-infra
+systemctl start spnego-infra
+
+# Show status
+echo ""
+echo "=== Service Status ==="
+systemctl status spnego-infra --no-pager
+
+echo ""
+echo "=== Installation Complete ==="
+echo ""
+echo "Commands:"
+echo "  systemctl status spnego-infra   # Check status"
+echo "  systemctl restart spnego-infra  # Restart"
+echo "  journalctl -u spnego-infra      # View logs"
+echo ""

--- a/ci/spnego-infra/setup-spnego-infra.sh
+++ b/ci/spnego-infra/setup-spnego-infra.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# SPNEGO Test Infrastructure Setup
+#
+# Run this on the jumpbox worker to set up KDC + Squid proxy for SPNEGO testing.
+# This script is idempotent - safe to run multiple times.
+#
+# Usage:
+#   sudo ./setup-spnego-infra.sh
+
+set -eux
+
+PROXY_PORT=13128
+REALM="TEST.LOCAL"
+TEST_USER="testuser"
+TEST_PASSWORD="testpass123"
+
+# Use internal registry to avoid Docker Hub rate limits
+DOCKER_REGISTRY="${DOCKER_REGISTRY:-tas-operability-docker-virtual.usw1.packages.broadcom.com}"
+DOCKER_REGISTRY_USERNAME="${DOCKER_REGISTRY_USERNAME:-svc-tas-operability}"
+DOCKER_REGISTRY_PASSWORD="${DOCKER_REGISTRY_PASSWORD:?ERROR: DOCKER_REGISTRY_PASSWORD environment variable must be set}"
+KRB5_IMAGE="${DOCKER_REGISTRY}/gcavalcante8808/krb5-server:latest"
+SQUID_IMAGE="${DOCKER_REGISTRY}/ubuntu/squid:latest"
+
+echo "=== Setting up SPNEGO Test Infrastructure ==="
+echo "Using registry: ${DOCKER_REGISTRY}"
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: Docker is not installed"
+    exit 1
+fi
+
+# Login to internal registry
+echo "Logging in to Docker registry..."
+echo "${DOCKER_REGISTRY_PASSWORD}" | docker login ${DOCKER_REGISTRY} -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
+
+# Cleanup existing containers
+echo "Cleaning up existing containers..."
+docker rm -f spnego-kdc spnego-proxy 2>/dev/null || true
+docker network rm spnego-net 2>/dev/null || true
+
+# Create network
+echo "Creating Docker network..."
+docker network create spnego-net
+
+# Start KDC
+# Port mappings are required so external clients can reach the KDC
+echo "Starting KDC container..."
+docker run -d \
+    --name spnego-kdc \
+    --hostname kdc.test.local \
+    --network spnego-net \
+    --network-alias kdc.test.local \
+    --restart unless-stopped \
+    -p 88:88/tcp \
+    -p 88:88/udp \
+    -p 464:464 \
+    -p 749:749 \
+    -e KRB5_REALM=${REALM} \
+    -e KRB5_KDC=kdc.test.local \
+    ${KRB5_IMAGE}
+
+# Wait for KDC to initialize
+echo "Waiting for KDC to initialize..."
+sleep 15
+
+# Create test principals
+echo "Creating Kerberos principals..."
+timeout 30 docker exec spnego-kdc kadmin.local -q "addprinc -pw ${TEST_PASSWORD} ${TEST_USER}@${REALM}" || true
+timeout 30 docker exec spnego-kdc kadmin.local -q "addprinc -pw proxypass HTTP/proxy.test.local@${REALM}" || true
+
+# Create Squid config
+echo "Creating Squid configuration..."
+cat > /tmp/squid.conf << 'EOF'
+http_port 3128
+acl all src all
+http_access allow all
+cache deny all
+access_log none
+cache_log /var/log/squid/cache.log
+EOF
+
+# Start Squid proxy
+echo "Starting Squid proxy container..."
+docker run -d \
+    --name spnego-proxy \
+    --hostname proxy.test.local \
+    --network spnego-net \
+    --restart unless-stopped \
+    -p 0.0.0.0:${PROXY_PORT}:3128 \
+    -v /tmp/squid.conf:/etc/squid/squid.conf:ro \
+    ${SQUID_IMAGE}
+
+# Wait for proxy to start
+sleep 5
+
+# Verify
+echo ""
+echo "=== Verifying Infrastructure ==="
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+# Test proxy
+echo ""
+echo "Testing proxy connectivity..."
+if curl -s --proxy http://localhost:${PROXY_PORT} --max-time 10 -I http://google.com 2>/dev/null | grep -q "HTTP/"; then
+    echo "Proxy is working!"
+else
+    echo "WARNING: Proxy test failed"
+fi
+
+# Get IP for clients
+HOST_IP=$(hostname -I | awk '{print $1}')
+
+# Verify KDC port is accessible
+echo ""
+echo "Testing KDC port..."
+if nc -z -w 2 localhost 88 2>/dev/null || ss -tlnp | grep -q ":88 "; then
+    echo "KDC port 88 is listening!"
+else
+    echo "WARNING: KDC port 88 may not be accessible"
+fi
+
+echo ""
+echo "=== SPNEGO Infrastructure Ready ==="
+echo ""
+echo "Host IP:     ${HOST_IP}"
+echo "Proxy URL:   http://${HOST_IP}:${PROXY_PORT}"
+echo "KDC Host:    ${HOST_IP}:88"
+echo "KDC Realm:   ${REALM}"
+echo "Test User:   ${TEST_USER}@${REALM}"
+echo "Password:    ${TEST_PASSWORD}"
+echo ""
+echo "For download-config.yml:"
+echo "  proxy-url: http://${HOST_IP}:${PROXY_PORT}"
+echo "  proxy-username: ${TEST_USER}"
+echo "  proxy-password: ${TEST_PASSWORD}"
+echo "  proxy-auth-type: spnego"
+echo ""
+echo "For krb5.conf, use KDC host: ${HOST_IP}"
+echo ""

--- a/ci/spnego-infra/spnego-infra.service
+++ b/ci/spnego-infra/spnego-infra.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=SPNEGO Test Infrastructure (KDC + Squid Proxy)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=120
+EnvironmentFile=/opt/spnego-infra/env
+ExecStart=/opt/spnego-infra/setup-spnego-infra.sh
+ExecStop=/usr/bin/docker rm -f spnego-kdc spnego-proxy
+ExecStop=/usr/bin/docker network rm spnego-net
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Enables SPNEGO/Kerberos proxy authentication for the existing download-product task. Enterprise environments that require Kerberos authentication for proxy access can now download products from Pivnet by configuring SPNEGO settings in their download-config.yml.

No new task required - the existing download-product.yml task supports SPNEGO when om CLI includes SPNEGO support.

## Dependencies
  - om CLI with SPNEGO support (will be included in platform-automation-image)
  - go-pivnet with SPNEGO transport support

## Configuration
SPNEGO proxy settings are configured in the download-config.yml file -
```
  pivnet-api-token: ((pivnet_token))
  pivnet-product-slug: ops-manager
  pivnet-file-glob: "*.ova"
  product-version-regex: '^2\.10\..*$'

  # SPNEGO proxy configuration
  proxy-url: http://proxy.corp.example.com:3128
  proxy-username: user@REALM.COM
  proxy-password: ((proxy_password))
  proxy-auth-type: spnego
  proxy-krb5-config: config/krb5.conf
```

  | Parameter         | Required | Description                                          |
  |-------------------|----------|------------------------------------------------------|
  | proxy-url         | Yes      | Proxy URL (e.g., http://proxy.corp.example.com:3128) |
  | proxy-username    | Yes      | Kerberos principal (e.g., user@REALM.COM)            |
  | proxy-password    | Yes      | Kerberos password                                    |
  | proxy-auth-type   | Yes      | Must be spnego                                       |
  | proxy-krb5-config | Yes      | Path to krb5.conf file                               |

## Example Usage
```
  - task: download-product
    image: platform-automation-image
    file: platform-automation-tasks/tasks/download-product.yml
    input_mapping:
      config: configuration
    params:
      CONFIG_FILE: download-config.yml
      SOURCE: pivnet
```

Example krb5.conf
```
  [libdefaults]
      default_realm = CORP.EXAMPLE.COM
      dns_lookup_realm = false
      dns_lookup_kdc = false

  [realms]
      CORP.EXAMPLE.COM = {
          kdc = kdc.corp.example.com
          admin_server = kdc.corp.example.com
      }

  [domain_realm]
      .corp.example.com = CORP.EXAMPLE.COM
      corp.example.com = CORP.EXAMPLE.COM
```