### PR TITLE
pin oci-build-task image tag to 0.14.0

### DIFF
--- a/ci/ci/pipeline.yml
+++ b/ci/ci/pipeline.yml
@@ -271,7 +271,7 @@ resources:
     bucket: ((platform-automation/main/s3_with_role.buckets.release_candidate))
     region_name: ((platform-automation/main/s3_with_role.region_name))
     key: version-v5.x
-    initial_version: 5.3.0
+    initial_version: 5.4.0
 - name: daily
   type: time
   source:
@@ -598,6 +598,7 @@ jobs:
         type: registry-image
         source:
           repository: ((concourse-team/dev_image_registry.url))/concourse/oci-build-task
+          tag: 0.14.0
           username: ((concourse-team/dev_image_registry.username))
           password: ((concourse-team/dev_image_registry.password))
       params:
@@ -628,6 +629,7 @@ jobs:
         type: registry-image
         source:
           repository: ((concourse-team/dev_image_registry.url))/concourse/oci-build-task
+          tag: 0.14.0
           username: ((concourse-team/dev_image_registry.username))
           password: ((concourse-team/dev_image_registry.password))
       params:


### PR DESCRIPTION
This PR pins oci-build-task image tag to 0.14.0