### PR TITLE
Revert Registry Token instructions to use refresh token for v5.2

### DIFF
--- a/docs/how-to-guides/_getting-started.html.md.erb
+++ b/docs/how-to-guides/_getting-started.html.md.erb
@@ -407,11 +407,8 @@ you must teach Concourse to talk to the Broadcom Support portal.
     Commands in this guide that contain a secret
     start with a space, which can be easy to miss.</p>
 
-2. Get a Registry Token from the Broadcom Support portal:
-    1. Log in to the [Broadcom Customer Support Portal](https://support.broadcom.com).
-    1. Navigate to **My Downloads** in the left-hand sidebar.
-    1. Click the **Registry Tokens** button at the top of the page.
-    1. Generate or copy your **Registry Token**.
+2. Get a refresh token from Quick Links on the right side of the Broadcom Support profile (when logged in) and click **Request New Refresh Token**.
+    Then use that token in the following command:
 
     ```bash
     # note the space before the command


### PR DESCRIPTION
The Registry Token (for container image pulls) was incorrectly referenced for the pivnet-refresh-token pipeline variable. The pivnet-refresh-token is a Tanzu Network API refresh token, not a Registry Token.