### PR TITLE
[TNZ-91341] Fix Terraform hang in Azure pipelines by disabling interactive input

### DIFF
--- a/ci/ci/pipeline.yml
+++ b/ci/ci/pipeline.yml
@@ -1168,6 +1168,11 @@ jobs:
       OM_PASSWORD: ((platform-automation/main/opsman-login.password))
       OM_USERNAME: ((platform-automation/main/opsman-login.username))
       PLATFORM_AUTOMATION_EMAIL: ((platform-automation/main.platform-automation-email))
+#@ if paving_dir == "azure":
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+      TF_VAR_client_secret: ""
+#@ end
     ensure:
       put: deployments
       tags: #@ tags
@@ -1405,6 +1410,11 @@ jobs:
         IAAS: #@ paving_dir
         DEPLOYMENT_NAME: #@ env_name
         PLATFORM_AUTOMATION_EMAIL: ((platform-automation/main.platform-automation-email))
+#@ if paving_dir == "azure":
+        TF_IN_AUTOMATION: "true"
+        TF_INPUT: "false"
+        TF_VAR_client_secret: ""
+#@ end
       ensure:
         put: deployments
         tags: #@ tags


### PR DESCRIPTION
### Root Cause
The Azure pipeline was intermittently hanging during Terraform operations. This was likely caused by Terraform pausing to wait for user input or confirmation in an environment where no interactive terminal is available.

### Changes
This PR updates `ci/ci/pipeline.yml` to ensure that when the `paving_dir` is set to `azure`, specific environment variables are injected to force non-interactive behavior.

* **`TF_IN_AUTOMATION`**: Set to `"true"` to optimize Terraform's output for automation logs.
* **`TF_INPUT`**: Set to `"false"` to prevent Terraform from prompting for input (which causes the "hang").
* **`TF_VAR_client_secret`**: Initialized as an empty string to satisfy variable requirements without manual intervention.

### Files Modified
* **[ci/ci/pipeline.yml](https://github.com/pivotal/docs-platform-automation/compare/personal/zachmerritt/fixed_terraform?expand=1#diff-8302061266857976865261899141028731057488950454359409867016629906)**: Added conditional logic (`# @ if paving_dir == "azure"`) to two separate job definitions to apply these environment variables.