### PR TITLE
Dockerfile.packages + Dockerfile.vsphere-only: optional authenticated pip index support

### DIFF
--- a/ci/ci/pipeline.yml
+++ b/ci/ci/pipeline.yml
@@ -534,6 +534,10 @@ jobs:
     params:
       DOCKERFILE: docs-platform-automation/ci/dockerfiles/Dockerfile.packages
       IMAGE_ARG_base_image: base-image/image.tar
+      BUILD_ARG_PIP_INDEX_URL_BASE: ((concourse-team/pip_index_url_base))
+      #! BuildKit secrets for pip auth (see Dockerfile.packages).
+      BUILDKIT_SECRETTEXT_artifactory_user: ((concourse-team/dev_image_registry.username))
+      BUILDKIT_SECRETTEXT_artifactory_pass: ((concourse-team/dev_image_registry.password))
   - put: packages-image
     get_params:
      format: oci
@@ -672,6 +676,9 @@ jobs:
       params:
         DOCKERFILE: docs-platform-automation/ci/dockerfiles/Dockerfile.vsphere-only
         IMAGE_ARG_base_image: binaries-image-oci/image.tar
+        BUILD_ARG_PIP_INDEX_URL_BASE: ((concourse-team/pip_index_url_base))
+        BUILDKIT_SECRETTEXT_artifactory_user: ((concourse-team/dev_image_registry.username))
+        BUILDKIT_SECRETTEXT_artifactory_pass: ((concourse-team/dev_image_registry.password))
       inputs:
         - name: docs-platform-automation
         - name: binaries-image-oci

--- a/ci/dockerfiles/Dockerfile.packages
+++ b/ci/dockerfiles/Dockerfile.packages
@@ -1,6 +1,9 @@
+# syntax=docker/dockerfile:1.4
 ARG base_image
 
 FROM ${base_image}
+
+ARG PIP_INDEX_URL_BASE=""
 
 # Install necessary binary
 USER root
@@ -33,31 +36,28 @@ ENV PATH /root/google-cloud-sdk/bin:$PATH
 RUN ln -s /root/google-cloud-sdk/bin/* /usr/local/bin/
 RUN gcloud --version
 
-# azure
-RUN pip3 install azure-cli
-RUN az --version
+# Python CLIs + CVE-pinned upgrades.
+# wheel: CVE-2022-40898. cryptography: CVE-2023-50782.
+# azure-core: CVE-2026-21226. docker: GHSA-x744-4wpc-v9h2 et al.
+RUN --mount=type=secret,id=artifactory_user,dst=/run/secrets/artifactory_user \
+    --mount=type=secret,id=artifactory_pass,dst=/run/secrets/artifactory_pass \
+    if [ -s /run/secrets/artifactory_user ] && [ -s /run/secrets/artifactory_pass ] && [ -n "$PIP_INDEX_URL_BASE" ]; then \
+        export PIP_INDEX_URL="https://$(cat /run/secrets/artifactory_user):$(cat /run/secrets/artifactory_pass)@${PIP_INDEX_URL_BASE}"; \
+        echo "pip: using internal index"; \
+    else \
+        echo "pip: using default public index"; \
+    fi && \
+    pip3 install \
+        azure-cli \
+        awscli \
+        python-openstackclient && \
+    pip3 install --upgrade \
+        "wheel>=0.38.1" \
+        "cryptography>=42.0.0" \
+        "azure-core>=1.38.0" \
+        "docker>=7.1.0"
 
-# aws
-RUN pip3 install awscli
-RUN aws --version
-
-# openstack
-RUN pip3 install python-openstackclient
-RUN openstack --version
-
-# Fix CVE-2022-40898 (GHSA-qwmp-2cf2-g9g6): Upgrade wheel to a secure version (>=0.38.1)
-RUN pip3 install --upgrade wheel>=0.38.1
-
-# Fix CVE-2023-50782: Upgrade cryptography to a secure version (>=42.0.0)
-# CVE-2023-50782: Bleichenbacher timing oracle attack in cryptography < 42.0.0
-RUN pip3 install --upgrade cryptography>=42.0.0
-
-# Fix CVE-2026-21226 (GHSA-jm66-cg57-jjv5): Upgrade azure-core to fix deserialization vulnerability
-# azure-core is exercised when om vm-lifecycle shells out to az CLI for Azure IaaS operations
-RUN pip3 install --upgrade azure-core>=1.38.0
-
-# Fix GHSA-x744-4wpc-v9h2, GHSA-4c29-8rgm-jvjj, GHSA-4vrq-3vrq-g6gg: Upgrade docker to a secure version
-RUN pip3 install --upgrade docker>=7.1.0
+RUN az --version && aws --version && openstack --version
 
 # Upgrade all packages
 RUN apt-get upgrade -y

--- a/ci/dockerfiles/Dockerfile.vsphere-only
+++ b/ci/dockerfiles/Dockerfile.vsphere-only
@@ -1,8 +1,16 @@
+# syntax=docker/dockerfile:1.4
 ARG base_image
 FROM ${base_image}
 
+ARG PIP_INDEX_URL_BASE=""
+
 # remove azure cli
-RUN pip3 install pip-autoremove
+RUN --mount=type=secret,id=artifactory_user,dst=/run/secrets/artifactory_user \
+    --mount=type=secret,id=artifactory_pass,dst=/run/secrets/artifactory_pass \
+    if [ -s /run/secrets/artifactory_user ] && [ -s /run/secrets/artifactory_pass ] && [ -n "$PIP_INDEX_URL_BASE" ]; then \
+        export PIP_INDEX_URL="https://$(cat /run/secrets/artifactory_user):$(cat /run/secrets/artifactory_pass)@${PIP_INDEX_URL_BASE}"; \
+    fi && \
+    pip3 install pip-autoremove
 RUN pip-autoremove -y azure-cli
 
 # remove AWS CLI


### PR DESCRIPTION
## Summary                                              
Allow `Dockerfile.packages` & `Dockerfile.vsphere-only` to optionally route pip installs through an authenticated package mirror when BuildKit secrets & a base URL are provided at build time. When any of these are absent, pip falls through to its default behavior (public PyPI), preserving the existing build experience.                                                                                                                                                   
                                                                                                                                                                                          
## Why                                                                                                                                                                                  
The `packages-image` & `vsphere-only-image` are currently produced by reaching directly to the public PyPI index. There are build environments where that isn't workable — for example, enterprise CI networks that require traffic to route through an authenticated package proxy, air-gapped  environments, or CI systems subject to corporate egress policy. 

BuildKit secrets are the standard way to pass credentials into a Docker build  without writing them into image layers or image history. This change adds support for them with zero impact on builders who don't need the capability.                                                                                                            