### PR TITLE
[TNZ-115746] Upgrade to python 3.12

### DIFF
--- a/ci/dockerfiles/Dockerfile.ci
+++ b/ci/dockerfiles/Dockerfile.ci
@@ -6,10 +6,22 @@ USER root
 
 ARG PIP_INDEX_URL_BASE=""
 
+ENV DEBIAN_FRONTEND=noninteractive
+# Install Python 3.12 via deadsnakes PPA
+# TO DO: This RUN code should be removed when upgrading to Ubuntu >24.04 (python 3.12 is a default Ubuntu >24.04)
+RUN apt-get update && apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && apt-get install -y \
+      python3.12 \
+      python3.12-dev \
+      python3.12-full \
+      python3.12-venv && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    python3.12 -m ensurepip --upgrade
+
 RUN apt-get -y update && apt-get -y install \
     rsync build-essential bash ca-certificates zip unzip curl gettext jq git wget tar xz-utils \
-    python3-pip python3-dev python3-setuptools openssl python3-cryptography libxml2-utils \
-    gnupg lsb-release openssh-server openssh-client
+    openssl libxml2-utils gnupg lsb-release openssh-server openssh-client
 
 RUN set -eux; \
     gover="$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -n1 | tr -d '\r\n')"; \

--- a/ci/dockerfiles/Dockerfile.packages
+++ b/ci/dockerfiles/Dockerfile.packages
@@ -7,6 +7,8 @@ ARG PIP_INDEX_URL_BASE=""
 
 # Install necessary binary
 USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y --no-install-recommends install \
     bash \
     build-essential \
@@ -29,6 +31,18 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     libxml2-utils \
   && true
 # netcat for `bosh ssh` -- the why is explained here: https://github.com/cloudfoundry/bosh-cli/issues/374
+
+# Install Python 3.12 via deadsnakes PPA
+# TO DO: This RUN code should be removed when upgrading to Ubuntu >24.04 (python 3.12 is a default Ubuntu >24.04)
+RUN apt-get update && apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && apt-get install -y \
+      python3.12 \
+      python3.12-dev \
+      python3.12-full \
+      python3.12-venv && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    python3.12 -m ensurepip --upgrade
 
 # gcloud
 RUN curl https://sdk.cloud.google.com > install.sh && bash install.sh --disable-prompts


### PR DESCRIPTION
CG4V4FLM93:docs-platform-automation hn901085$ docker run --rm --platform linux/amd64 -v $(pwd)/ci/scri
pts:/scripts -w /scripts/tests pa-ci-local python3 -m pytest . -v --tb=short
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /scripts/tests
collecting ... collected 49 items

test_blackduck_carry_forward.py::TestGetPreviousComponentData::test_builds_name_only_map PASSED [  2%]
test_blackduck_carry_forward.py::TestGetPreviousComponentData::test_filters_by_license_policy_category PASSED [  4%]
test_blackduck_carry_forward.py::TestGetPreviousComponentData::test_handles_pagination PASSED [  6%]
test_blackduck_carry_forward.py::TestGetPreviousComponentData::test_stores_usages_by_name_and_version PASSED [  8%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_also_carries_comment_on_exact_match PASSED [ 10%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_dry_run_does_not_call_put PASSED [ 12%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_exact_match_carries_usage PASSED [ 14%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_handles_pagination PASSED [ 16%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_name_only_match_carries_usage PASSED [ 18%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_skips_ignored_components PASSED [ 20%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_skips_non_in_violation_components PASSED [ 22%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_skips_when_no_match_in_previous PASSED [ 24%]
test_blackduck_carry_forward.py::TestCarryForwardData::test_skips_when_usage_already_matches PASSED [ 26%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_empty_component_list_passes PASSED [ 28%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_fails_when_component_missing_usage PASSED [ 30%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_filters_request_by_license_policy_category PASSED [ 32%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_handles_pagination_all_compliant PASSED [ 34%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_handles_pagination_fail_on_page2 PASSED [ 36%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_mixed_components_fails_on_missing_usage PASSED [ 38%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_only_checks_usages_not_comment PASSED [ 40%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_passes_when_all_components_have_usage PASSED [ 42%]
test_blackduck_check_compliance.py::TestCheckCompliance::test_skips_non_in_violation_components PASSED [ 44%]
test_generate_osl_report.py::TestBuildJobUrl::test_buildwithparameters_suffix PASSED [ 46%]
test_generate_osl_report.py::TestBuildJobUrl::test_hyphen_not_encoded PASSED [ 48%]
test_generate_osl_report.py::TestBuildJobUrl::test_matches_expected_url PASSED [ 51%]
test_generate_osl_report.py::TestBuildJobUrl::test_nested_job_has_job_between_segments PASSED [ 53%]
test_generate_osl_report.py::TestBuildJobUrl::test_single_level_job PASSED [ 55%]
test_generate_osl_report.py::TestBuildJobUrl::test_spaces_encoded_as_percent20 PASSED [ 57%]
test_generate_osl_report.py::TestGetCrumb::test_404_returns_empty_dict PASSED [ 59%]
test_generate_osl_report.py::TestGetCrumb::test_no_jsessionid_in_result PASSED [ 61%]
test_generate_osl_report.py::TestGetCrumb::test_returns_crumb_header_dict PASSED [ 63%]
test_generate_osl_report.py::TestTriggerBuild::test_500_exits PASSED     [ 65%]
test_generate_osl_report.py::TestTriggerBuild::test_all_four_params_sent PASSED [ 67%]
test_generate_osl_report.py::TestTriggerBuild::test_blackduck_instance_uses_hyphen_bd_vm PASSED [ 69%]
test_generate_osl_report.py::TestTriggerBuild::test_correct_trigger_url PASSED [ 71%]
test_generate_osl_report.py::TestTriggerBuild::test_crumb_sent_in_post_headers PASSED [ 73%]
test_generate_osl_report.py::TestTriggerBuild::test_params_in_query_string_no_body PASSED [ 75%]
test_generate_osl_report.py::TestTriggerBuild::test_queue_url_has_api_json_suffix PASSED [ 77%]
test_generate_osl_report.py::TestWaitForBuildStart::test_cancelled_exits PASSED [ 79%]
test_generate_osl_report.py::TestWaitForBuildStart::test_polls_until_assigned PASSED [ 81%]
test_generate_osl_report.py::TestWaitForBuildStart::test_returns_build_url PASSED [ 83%]
test_generate_osl_report.py::TestWaitForBuildCompletion::test_failure_exits PASSED [ 85%]
test_generate_osl_report.py::TestWaitForBuildCompletion::test_polls_while_building PASSED [ 87%]
test_generate_osl_report.py::TestWaitForBuildCompletion::test_success_returns_build_info PASSED [ 89%]
test_generate_osl_report.py::TestWaitForBuildCompletion::test_timeout_exits PASSED [ 91%]
test_generate_osl_report.py::TestDownloadOslArtifact::test_canonical_rmt_filename PASSED [ 93%]
test_generate_osl_report.py::TestDownloadOslArtifact::test_fallback_when_exact_name_not_found PASSED [ 95%]
test_generate_osl_report.py::TestDownloadOslArtifact::test_finds_artifact_by_output_file_name PASSED [ 97%]
test_generate_osl_report.py::TestDownloadOslArtifact::test_no_artifacts_exits PASSED [100%]

============================== 49 passed in 0.69s ==============================

ai-assisted=yes