### PR TITLE
Add Renovate config and version annotations for packer toolchain

### DIFF
--- a/ci/dockerfiles/Dockerfile.binaries
+++ b/ci/dockerfiles/Dockerfile.binaries
@@ -53,6 +53,7 @@ RUN chmod +x \
 # Install Packer
 ENV CHECKPOINT_DISABLE=1
 ENV PACKER_PLUGIN_PATH=/root/.packer.d/plugins
+# renovate: datasource=github-releases depName=hashicorp/packer versioning=semver
 ENV PACKER_VERSION=1.16.0
 RUN wget -q https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
     && unzip -o packer_${PACKER_VERSION}_linux_amd64.zip \
@@ -61,12 +62,14 @@ RUN wget -q https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PAC
     && rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
 # Create Packer plugin directory and install vsphere plugin
+# renovate: datasource=github-releases depName=vmware/packer-plugin-vsphere versioning=semver extractVersion=^v(?<version>.*)$
+ENV PACKER_PLUGIN_VSPHERE_VERSION=2.3.0
 RUN mkdir -p /root/.packer.d/plugins \
     && cd /root/.packer.d/plugins \
-    && wget -q https://github.com/vmware/packer-plugin-vsphere/releases/download/v2.3.0/packer-plugin-vsphere_v2.3.0_x5.0_linux_amd64.zip \
-    && unzip packer-plugin-vsphere_v2.3.0_x5.0_linux_amd64.zip \
-    && chmod +x packer-plugin-vsphere_v2.3.0_x5.0_linux_amd64 \
-    && rm -f packer-plugin-vsphere_v2.3.0_x5.0_linux_amd64.zip
+    && wget -q https://github.com/vmware/packer-plugin-vsphere/releases/download/v${PACKER_PLUGIN_VSPHERE_VERSION}/packer-plugin-vsphere_v${PACKER_PLUGIN_VSPHERE_VERSION}_x5.0_linux_amd64.zip \
+    && unzip packer-plugin-vsphere_v${PACKER_PLUGIN_VSPHERE_VERSION}_x5.0_linux_amd64.zip \
+    && chmod +x packer-plugin-vsphere_v${PACKER_PLUGIN_VSPHERE_VERSION}_x5.0_linux_amd64 \
+    && rm -f packer-plugin-vsphere_v${PACKER_PLUGIN_VSPHERE_VERSION}_x5.0_linux_amd64.zip
 
 # Verify Packer installation
 RUN packer version

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,93 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":semanticCommitsDisabled",
+  ],
+  baseBranches: ["develop"],
+  timezone: "America/Los_Angeles",
+  schedule: ["before 6am on monday"],
+  labels: ["dependencies"],
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+  rangeStrategy: "bump",
+
+  packageRules: [
+    // Group all patch-level bumps across ecosystems to cut PR noise
+    {
+      matchUpdateTypes: ["patch"],
+      groupName: "patch updates",
+      automerge: false,
+    },
+    // Low-risk internal tooling: group minor+patch (manual review, no automerge)
+    {
+      matchManagers: ["gomod"],
+      groupName: "go dependencies",
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: false,
+    },
+    {
+      matchManagers: ["bundler"],
+      groupName: "ruby dependencies (secrets-verifier)",
+    },
+    // CLI/binary tools pulled via custom regex managers — group per pipeline concern
+    {
+      matchManagers: ["regex"],
+      matchPackageNames: ["hashicorp/packer", "vmware/packer-plugin-vsphere"],
+      groupName: "packer toolchain",
+    },
+    // Docker base images and Concourse resource images: group patch/digest updates
+    {
+      matchManagers: ["dockerfile", "regex"],
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      groupName: "container image updates",
+    },
+    // Major version bumps always get their own PR, never grouped, never automerged
+    {
+      matchUpdateTypes: ["major"],
+      groupName: null,
+      automerge: false,
+      labels: ["dependencies", "major-update"],
+    },
+  ],
+
+  customManagers: [
+    // Generic: any "# renovate: ..." annotated VERSION=/ENV FOO_VERSION= line in Dockerfiles or shell scripts
+    // (ci/dockerfiles/Dockerfile.ci intentionally excluded from this pass)
+    {
+      customType: "regex",
+      fileMatch: [
+        "^ci/dockerfiles/Dockerfile\\.binaries$",
+        "^tasks/build-windows-stemcell\\.sh$",
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s*\\n\\s*(ENV\\s+)?[A-Z_]+_VERSION=[\"']?(?<currentValue>[\\w.-]+)[\"']?",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    // Concourse image_resource / registry-image resource tag pins (semver-shaped tags only)
+    {
+      customType: "regex",
+      fileMatch: [
+        "^ci/ci/pipeline\\.yml$",
+        "^ci/tasks/.*\\.yml$",
+        "^ci/python-mitigation-support/pipeline\\.yml$",
+        "^ci/osspi-tpe-ci/pipeline\\.yml$",
+      ],
+      matchStrings: [
+        "repository:\\s*(?<depName>[a-zA-Z0-9._/-]+)\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>\\d[\\w.-]*)[\"']?",
+      ],
+      datasourceTemplate: "docker",
+    },
+  ],
+
+  vulnerabilityAlerts: {
+    enabled: true,
+    labels: ["security"],
+  },
+
+  ignorePaths: [
+    "external/**",
+  ],
+}

--- a/tasks/build-windows-stemcell.sh
+++ b/tasks/build-windows-stemcell.sh
@@ -208,7 +208,8 @@ export NO_PROXY="$(no_proxy_with_github "${NO_PROXY:-}")"
 
 # ---- Packer vsphere plugin ----
 # HTTP_PROXY/HTTPS_PROXY are set only after this block so plugin download is direct or uses NO_PROXY.
-VERSION="2.1.2"
+# renovate: datasource=github-releases depName=vmware/packer-plugin-vsphere versioning=semver extractVersion=^v(?<version>.*)$
+VERSION="2.3.0"
 PLUGIN_NAME="vsphere"
 SOURCE="github.com/vmware/vsphere"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Adds renovate.json5 to automate dependency PRs for Go modules, the Gemfile, and Concourse pipeline image tags, plus custom regex managers for hardcoded CLI versions. Annotates the packer/packer-plugin-vsphere version pins in Dockerfile.binaries and build-windows-stemcell.sh with renovate datasource comments, and resyncs the plugin version in the stemcell script (2.1.2 -> 2.3.0) to match Dockerfile.binaries.