### PR TITLE
Expose unsafe-dependency-bypass params in the apply-changes task

### DIFF
--- a/docs/tasks/_apply-changes-script.html.md.erb
+++ b/docs/tasks/_apply-changes-script.html.md.erb
@@ -13,6 +13,13 @@ if [ "${IGNORE_WARNINGS}" == "true" ]; then
   flags+=("--ignore-warnings")
 fi
 
+# --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion
+# require Ops Manager 11.0+ and an om CLI build that includes these
+# flags. Against an older Ops Manager, om itself errors with "only
+# available with Ops Manager 11.0 or later" rather than silently
+# sending a field the older Ops Manager wouldn't recognize. Against
+# an om CLI build that predates these flags, this task instead fails
+# with an "unknown flag" error from om's own CLI parser.
 if [ "${ALLOW_UNSAFE_DEPENDENCY_UPDATE}" == "true" ]; then
   flags+=("--allow-unsafe-dependency-update")
 fi

--- a/docs/tasks/_apply-changes-script.html.md.erb
+++ b/docs/tasks/_apply-changes-script.html.md.erb
@@ -13,6 +13,14 @@ if [ "${IGNORE_WARNINGS}" == "true" ]; then
   flags+=("--ignore-warnings")
 fi
 
+if [ "${ALLOW_UNSAFE_DEPENDENCY_UPDATE}" == "true" ]; then
+  flags+=("--allow-unsafe-dependency-update")
+fi
+
+if [ "${ALLOW_UNSAFE_DEPENDENCY_DELETION}" == "true" ]; then
+  flags+=("--allow-unsafe-dependency-deletion")
+fi
+
 if [ -n "${ERRAND_CONFIG_FILE}" ]; then
   flags+=("--config" "${ERRAND_CONFIG_FILE}")
 fi

--- a/docs/tasks/_apply-changes.html.md.erb
+++ b/docs/tasks/_apply-changes.html.md.erb
@@ -34,6 +34,16 @@ params:
   # - This is not recommended unless unless the warning failure(s)
   #   are well understood.
 
+  ALLOW_UNSAFE_DEPENDENCY_UPDATE: false
+  # - Optional
+  # - If true, allows apply-changes to proceed even when it would
+  #   update an optional dependency out of its declared safe order.
+
+  ALLOW_UNSAFE_DEPENDENCY_DELETION: false
+  # - Optional
+  # - If true, allows apply-changes to proceed even when it would
+  #   delete an optional dependency not marked as safe to delete.
+
   SELECTIVE_DEPLOY_PRODUCTS:
   # - Optional
   # - Comma separated list of products for apply changes.

--- a/docs/tasks/_apply-changes.html.md.erb
+++ b/docs/tasks/_apply-changes.html.md.erb
@@ -38,11 +38,24 @@ params:
   # - Optional
   # - If true, allows apply-changes to proceed even when it would
   #   update an optional dependency out of its declared safe order.
+  # - Requires Ops Manager 11.0 or later and an om CLI build that
+  #   includes the --allow-unsafe-dependency-update flag.
+  #   - Against an older Ops Manager, om itself will refuse to
+  #     proceed with a clear "only available with Ops Manager 11.0
+  #     or later" error, rather than silently sending a field the
+  #     older Ops Manager wouldn't recognize.
+  #   - If the om CLI binary in this pipeline predates the flag
+  #     being added at all, setting this to true instead fails the
+  #     task with an "unknown flag" error from om's own CLI parser,
+  #     before any request is made.
 
   ALLOW_UNSAFE_DEPENDENCY_DELETION: false
   # - Optional
   # - If true, allows apply-changes to proceed even when it would
   #   delete an optional dependency not marked as safe to delete.
+  # - Same version requirements and failure modes as
+  #   ALLOW_UNSAFE_DEPENDENCY_UPDATE above: Ops Manager 11.0+ and an
+  #   om CLI build that includes --allow-unsafe-dependency-deletion.
 
   SELECTIVE_DEPLOY_PRODUCTS:
   # - Optional

--- a/tasks/apply-changes.sh
+++ b/tasks/apply-changes.sh
@@ -18,6 +18,14 @@ if [ "${FORCE_LATEST_VARIABLES}" == "true" ]; then
   flags+=("--force_latest_variables")
 fi
 
+if [ "${ALLOW_UNSAFE_DEPENDENCY_UPDATE}" == "true" ]; then
+  flags+=("--allow-unsafe-dependency-update")
+fi
+
+if [ "${ALLOW_UNSAFE_DEPENDENCY_DELETION}" == "true" ]; then
+  flags+=("--allow-unsafe-dependency-deletion")
+fi
+
 if [ -n "${ERRAND_CONFIG_FILE}" ]; then
   flags+=("--config" "${ERRAND_CONFIG_FILE}")
 fi

--- a/tasks/apply-changes.sh
+++ b/tasks/apply-changes.sh
@@ -18,6 +18,13 @@ if [ "${FORCE_LATEST_VARIABLES}" == "true" ]; then
   flags+=("--force_latest_variables")
 fi
 
+# --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion
+# require Ops Manager 11.0+ and an om CLI build that includes these
+# flags. Against an older Ops Manager, om itself errors with "only
+# available with Ops Manager 11.0 or later" rather than silently
+# sending a field the older Ops Manager wouldn't recognize. Against
+# an om CLI build that predates these flags, this task instead fails
+# with an "unknown flag" error from om's own CLI parser.
 if [ "${ALLOW_UNSAFE_DEPENDENCY_UPDATE}" == "true" ]; then
   flags+=("--allow-unsafe-dependency-update")
 fi

--- a/tasks/apply-changes.yml
+++ b/tasks/apply-changes.yml
@@ -46,6 +46,16 @@ params:
   # - This is to provide an alternative to stemcell updates
   #   in order to manually rotate automatically-rotated certificates.
 
+  ALLOW_UNSAFE_DEPENDENCY_UPDATE: false
+  # - Optional
+  # - If true, allows apply-changes to proceed even when it would
+  #   update an optional dependency out of its declared safe order.
+
+  ALLOW_UNSAFE_DEPENDENCY_DELETION: false
+  # - Optional
+  # - If true, allows apply-changes to proceed even when it would
+  #   delete an optional dependency not marked as safe to delete.
+
   SELECTIVE_DEPLOY_PRODUCTS:
   # - Optional
   # - Comma separated list of products for apply changes.

--- a/tasks/apply-changes.yml
+++ b/tasks/apply-changes.yml
@@ -50,11 +50,24 @@ params:
   # - Optional
   # - If true, allows apply-changes to proceed even when it would
   #   update an optional dependency out of its declared safe order.
+  # - Requires Ops Manager 11.0 or later and an om CLI build that
+  #   includes the --allow-unsafe-dependency-update flag.
+  #   - Against an older Ops Manager, om itself will refuse to
+  #     proceed with a clear "only available with Ops Manager 11.0
+  #     or later" error, rather than silently sending a field the
+  #     older Ops Manager wouldn't recognize.
+  #   - If the om CLI binary in this pipeline predates the flag
+  #     being added at all, setting this to true instead fails the
+  #     task with an "unknown flag" error from om's own CLI parser,
+  #     before any request is made.
 
   ALLOW_UNSAFE_DEPENDENCY_DELETION: false
   # - Optional
   # - If true, allows apply-changes to proceed even when it would
   #   delete an optional dependency not marked as safe to delete.
+  # - Same version requirements and failure modes as
+  #   ALLOW_UNSAFE_DEPENDENCY_UPDATE above: Ops Manager 11.0+ and an
+  #   om CLI build that includes --allow-unsafe-dependency-deletion.
 
   SELECTIVE_DEPLOY_PRODUCTS:
   # - Optional


### PR DESCRIPTION
Context:
The apply-changes Concourse task wraps the om CLI's apply-changes command and only exposes a subset of its flags as task params (RECREATE, IGNORE_WARNINGS, FORCE_LATEST_VARIABLES, SELECTIVE_DEPLOY_PRODUCTS, ERRAND_CONFIG_FILE). The om CLI recently gained two new flags that let a Platform Engineer bypass Ops Manager's safety checks around updating an optional tile dependency out of its declared safe order, or deleting one that isn't marked safe to delete. Without this change, pipeline authors using this task have no way to pass those two flags through — they'd have to bypass the task entirely and shell out to `om` directly, defeating the point of using a versioned, documented task interface.

Implementation notes:
- Added ALLOW_UNSAFE_DEPENDENCY_UPDATE and ALLOW_UNSAFE_DEPENDENCY_DELETION params to tasks/apply-changes.yml (both default false), and matching conditionals in tasks/apply-changes.sh that append --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion to the `om apply-changes` invocation only when set to true — mirroring the existing IGNORE_WARNINGS pattern exactly.
- This task change is purely a pass-through; it has no effect by itself unless both ends of the chain support it:
  - om CLI side: requires an om build that includes the --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion flags added on the `feat/allow-unsafe-dependency-flags` branch in the om repo. That branch is not yet merged or released — the latest tagged om release (7.21.7) does not have these flags. Pinning a pipeline to an om version older than whichever release first includes them means these task params will be silently rejected by `om`'s flag parser (an "unknown flag" CLI error), not silently ignored.
  - Ops Manager side: requires an Ops Manager release that accepts allow_unsafe_dependency_update / allow_unsafe_dependency_deletion on POST /api/v0/installations. That backend support already shipped in Ops Manager releases/11.0. Against an older Ops Manager, om sends the fields but Ops Manager silently strips them via Rails strong-parameter filtering — the flags become a no-op rather than an error in that direction.
- Also updated the two doc-site pages that mirror the task YAML/ script (docs/tasks/_apply-changes.html.md.erb and _apply-changes-script.html.md.erb) with the same two params, so the published task reference stays in sync.

Usage notes:
- Set ALLOW_UNSAFE_DEPENDENCY_UPDATE: true and/or ALLOW_UNSAFE_DEPENDENCY_DELETION: true as task params in a pipeline's apply-changes step, same as existing params like IGNORE_WARNINGS.
- Both default to false and are no-ops unless explicitly set.
- These only take effect once the pipeline's om CLI version includes the underlying flags — until then, setting either param to true will cause `om` to fail on an unrecognized flag; do not enable them until the pipeline's om version is confirmed to support them.

Other notes:
- Pre-existing, unrelated to this change: FORCE_LATEST_VARIABLES's shell branch appends --force_latest_variables (underscore) instead of the real om flag --force-latest-variables (hyphen). Not fixed here; the two new params use the correct hyphenated flag names to avoid replicating that bug.
- The doc-site erb files were already missing FORCE_LATEST_VARIABLES entirely (pre-existing drift, not caused by this change) and aren't covered by any automated content-sync test; left as-is beyond adding this change's own two params.
- tests/docs_test.go and tests/shellcheck_test.go both have pre-existing, unrelated failures in this checkout (a missing docs/tasks.md file, and a shellcheck violation in a different task's script) — confirmed via `git stash` that both predate this change; shellcheck passes clean on the modified tasks/apply-changes.sh itself.