### PR TITLE
[TNZ-144854] Fix healthwatch file glob to match single product

### DIFF
--- a/ci/opsman-support/pipeline.yml
+++ b/ci/opsman-support/pipeline.yml
@@ -64,13 +64,6 @@ resources:
       private: false
       regexp: #@ "^example-product-(" + opsman_version.replace('.', '\.') + ".*)\.pivotal$"
 #@ end
-  - name: stemcells-ubuntu-xenial
-    type: pivnet
-    source:
-      api_token: ((platform-automation/main.pivnet_token))
-      product_slug: stemcells-ubuntu-xenial
-      product_version: ^621\..*
-  
   - name: stemcells-ubuntu-jammy
     type: pivnet
     source:
@@ -86,18 +79,11 @@ jobs:
   serial_groups: ["install"]
   plan:
   - in_parallel:
-    - get: stemcells-ubuntu-xenial
-      params:
-        globs:
-          - '*vsphere*.tgz'
-      tags: *common-tags
-    #@ if opsman_version == "3.0" or opsman_version == "3.1":
     - get: stemcells-ubuntu-jammy
       params:
         globs:
           - '*vsphere*.tgz'
       tags: *common-tags
-    #@ end
     - get: #@ "example-product-" + opsman_version
       tags: *common-tags
     - get: #@ "opsman-image-" + opsman_version
@@ -239,9 +225,7 @@ jobs:
       product: #@ "example-product-" + opsman_version
       env: deployments
       config: deployments
-      #@ if opsman_version == "3.0" or opsman_version == "3.1":
       stemcell: stemcells-ubuntu-jammy
-      #@ end
     params:
       ENV_FILE: ci-support-epc/env.yml
       CONFIG_FILE: ci-support-epc/example-product.yml

--- a/ci/tasks/download-product.yml
+++ b/ci/tasks/download-product.yml
@@ -37,7 +37,7 @@ run:
     pivnet-api-token: $OM_pivnet_token
     pivnet-file-glob: "*.pivotal"
     pivnet-product-slug: p-healthwatch
-    product-version: 1.8.8
+    product-version: 2.3.5
     stemcell-iaas: google
 
     s3-access-key-id: minio
@@ -53,7 +53,7 @@ run:
       --vars-env OM
 
     test -e downloads-pivnet/\[p-healthwatch,*\]*.pivotal
-    test -e downloads-pivnet/\[stemcells-ubuntu-xenial,*\]*.tgz
+    test -e downloads-pivnet/\[stemcells-ubuntu-jammy,*\]*.tgz
 
     ls downloads-pivnet/
 
@@ -72,5 +72,5 @@ run:
 
 
     test -e downloads-s3/\[p-healthwatch,*\]*.pivotal
-    test -e downloads-s3/\[stemcells-ubuntu-xenial,*\]*.tgz
+    test -e downloads-s3/\[stemcells-ubuntu-jammy,*\]*.tgz
     pkill -9 minio

--- a/ci/tasks/download-product.yml
+++ b/ci/tasks/download-product.yml
@@ -35,7 +35,7 @@ run:
     cat > config/download-product.yml <<EOL
     ---
     pivnet-api-token: $OM_pivnet_token
-    pivnet-file-glob: "*.pivotal"
+    pivnet-file-glob: "healthwatch-2*.pivotal"
     pivnet-product-slug: p-healthwatch
     product-version: 2.3.5
     stemcell-iaas: google

--- a/docs/examples/_download-stemcell-product.html.md.erb
+++ b/docs/examples/_download-stemcell-product.html.md.erb
@@ -3,7 +3,7 @@
 ---
 pivnet-api-token: token
 pivnet-file-glob: "*vsphere*"       # must be quoted if starting with a *
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 
 # Either product-version OR product-version-regex is required
 # product-version-regex: ^250\..*$  # must not be quoted

--- a/docs/inputs-outputs.html.md.erb
+++ b/docs/inputs-outputs.html.md.erb
@@ -556,7 +556,7 @@ using the [download-product](./tasks.html#download-product) task.
 ---
 pivnet-api-token: token
 pivnet-file-glob: "bosh-stemcell-*-aws*.tgz"
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 product-version-regex: ^170\..*$
 ```
 
@@ -566,7 +566,7 @@ product-version-regex: ^170\..*$
 ---
 pivnet-api-token: token
 pivnet-file-glob: "bosh-stemcell-*-azure*.tgz"
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 product-version-regex: ^170\..*$
 ```
 
@@ -576,7 +576,7 @@ product-version-regex: ^170\..*$
 ---
 pivnet-api-token: token
 pivnet-file-glob: "bosh-stemcell-*-google*.tgz"
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 product-version-regex: ^170\..*$
 ```
 
@@ -586,7 +586,7 @@ product-version-regex: ^170\..*$
 ---
 pivnet-api-token: token
 pivnet-file-glob: "bosh-stemcell-*-openstack*.tgz"
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 product-version-regex: ^170\..*$
 ```
 
@@ -596,7 +596,7 @@ product-version-regex: ^170\..*$
 ---
 pivnet-api-token: token
 pivnet-file-glob: "bosh-stemcell-*-vsphere*.tgz"
-pivnet-product-slug: stemcells-ubuntu-xenial
+pivnet-product-slug: stemcells-ubuntu-jammy
 product-version-regex: ^170\..*$
 ```
 

--- a/docs/pipelines/resources.html.md.erb
+++ b/docs/pipelines/resources.html.md.erb
@@ -167,7 +167,7 @@ resources:
     bucket: ((s3_pivnet_products_bucket))
     region_name: ((s3_region_name))
     secret_access_key: ((s3_secret_access_key))
-    regexp: pks-stemcell/\[stemcells-ubuntu-xenial,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
+    regexp: pks-stemcell/\[stemcells-ubuntu-jammy,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
 
 - name: tas-product
   type: s3
@@ -185,7 +185,7 @@ resources:
     bucket: ((s3_pivnet_products_bucket))
     region_name: ((s3_region_name))
     secret_access_key: ((s3_secret_access_key))
-    regexp: tas-stemcell/\[stemcells-ubuntu-xenial,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
+    regexp: tas-stemcell/\[stemcells-ubuntu-jammy,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
 
 - name: healthwatch-product
   type: s3
@@ -221,7 +221,7 @@ resources:
     bucket: ((s3_pivnet_products_bucket))
     region_name: ((s3_region_name))
     secret_access_key: ((s3_secret_access_key))
-    regexp: healthwatch-stemcell/\[stemcells-ubuntu-xenial,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
+    regexp: healthwatch-stemcell/\[stemcells-ubuntu-jammy,(.*)\]light-bosh-stemcell-.*-google.*\.tgz
 
 - name: telemetry-product
   type: s3


### PR DESCRIPTION
Description
What does this PR do? This PR fixes a pipeline failure in the download-product task tests caused by a glob matching multiple files.

Why are we making this change? After upgrading the download-product test to use p-healthwatch version 2.3.5, the test began failing with the following error:


```
could not download product: for product version 2.3.5: the glob '*.pivotal' matches multiple files. Write your glob to match exactly one of the following:
  healthwatch-2.3.5.pivotal
  healthwatch-pas-exporter-2.3.5.pivotal
  healthwatch-pks-exporter-2.3.5.pivotal
```

Because om download-product requires the glob to match exactly one file, the generic *.pivotal glob fails on releases that include multiple .pivotal assets.

Specific Changes:

ci/tasks/download-product.yml: Updated pivnet-file-glob from "*.pivotal" to "healthwatch-2*.pivotal". This strictly matches the main product file and ignores the PAS and PKS exporter files.