### PR TITLE
[TNZ-144854] Fix healthwatch file glob to match single product

### DIFF
--- a/ci/tasks/download-product.yml
+++ b/ci/tasks/download-product.yml
@@ -35,7 +35,7 @@ run:
     cat > config/download-product.yml <<EOL
     ---
     pivnet-api-token: $OM_pivnet_token
-    pivnet-file-glob: "*.pivotal"
+    pivnet-file-glob: "healthwatch-2*.pivotal"
     pivnet-product-slug: p-healthwatch
     product-version: 1.8.8
     stemcell-iaas: google


### PR DESCRIPTION
Description
What does this PR do? This PR fixes a pipeline failure in the download-product task tests caused by a glob matching multiple files.

Why are we making this change? When downloading p-healthwatch version 2.3.5, the download-product task fails with the following error:

```
could not download product: for product version 2.3.5: the glob '*.pivotal' matches multiple files. Write your glob to match exactly one of the following:
  healthwatch-2.3.5.pivotal
  healthwatch-pas-exporter-2.3.5.pivotal
  healthwatch-pks-exporter-2.3.5.pivotal
```
Because om download-product requires the glob to match exactly one file, the generic *.pivotal glob fails on releases that include multiple .pivotal assets.

Specific Changes:

ci/tasks/download-product.yml: Updated pivnet-file-glob from "*.pivotal" to "healthwatch-2*.pivotal". This strictly matches the main product file and ignores the PAS and PKS exporter files.